### PR TITLE
Better error handling

### DIFF
--- a/MEGAHIT.spec
+++ b/MEGAHIT.spec
@@ -11,7 +11,7 @@ module MEGAHIT {
 		read_library_ref - the name of the PE read library (SE library support in the future)
 		output_contig_set_name - the name of the output contigset
 
-		megahit_parameter_preset - 
+		megahit_parameter_preset -
 			override a group of parameters; possible values:
             meta            '--min-count 2 --k-list 21,41,61,81,99'
                             (generic metagenomes, default)
@@ -35,6 +35,9 @@ module MEGAHIT {
 
 		min_contig_length - minimum length of contigs to output, default is 2000
 
+		max_mem_percnet - maximum memory to make available to MEGAHIT, as a percentage of
+						  available system memory (optional, default = 0.9 or 90%)
+
 		@optional megahit_parameter_preset
 		@optional min_count
 		@optional k_min
@@ -42,6 +45,7 @@ module MEGAHIT {
 		@optional k_step
 		@optional k_list
 		@optional min_contig_length
+		@optional max_mem_percent
 	*/
 	typedef structure {
 		string workspace_name;
@@ -56,6 +60,7 @@ module MEGAHIT {
 		int k_step;
 		list <int> k_list;
 		int min_contig_length;
+		float max_mem_percent;
 	} MegaHitParams;
 
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -11,7 +11,7 @@ service-language:
     python
 
 module-version:
-    2.3.1
+    2.4.0
 
 owners:
     [msneddon, rsutormin, dylan, mclark58]

--- a/lib/MEGAHIT/MEGAHITClient.pm
+++ b/lib/MEGAHIT/MEGAHITClient.pm
@@ -132,6 +132,7 @@ MegaHitParams is a reference to a hash where the following keys are defined:
 	k_step has a value which is an int
 	k_list has a value which is a reference to a list where each element is an int
 	min_contig_length has a value which is an int
+	max_mem_percent has a value which is a float
 MegaHitOutput is a reference to a hash where the following keys are defined:
 	report_name has a value which is a string
 	report_ref has a value which is a string
@@ -155,6 +156,7 @@ MegaHitParams is a reference to a hash where the following keys are defined:
 	k_step has a value which is an int
 	k_list has a value which is a reference to a list where each element is an int
 	min_contig_length has a value which is an int
+	max_mem_percent has a value which is a float
 MegaHitOutput is a reference to a hash where the following keys are defined:
 	report_name has a value which is a string
 	report_ref has a value which is a string
@@ -319,7 +321,7 @@ workspace_name - the name of the workspace for input/output
 read_library_ref - the name of the PE read library (SE library support in the future)
 output_contig_set_name - the name of the output contigset
 
-megahit_parameter_preset - 
+megahit_parameter_preset -
         override a group of parameters; possible values:
             meta            '--min-count 2 --k-list 21,41,61,81,99'
             (generic metagenomes, default)
@@ -343,6 +345,9 @@ min_count - minimum multiplicity for filtering (k_min+1)-mers, default 2
 
 min_contig_length - minimum length of contigs to output, default is 2000
 
+max_mem_percnet - maximum memory to make available to MEGAHIT, as a percentage of
+                                  available system memory (optional, default = 0.9 or 90%)
+
 @optional megahit_parameter_preset
 @optional min_count
 @optional k_min
@@ -350,6 +355,7 @@ min_contig_length - minimum length of contigs to output, default is 2000
 @optional k_step
 @optional k_list
 @optional min_contig_length
+@optional max_mem_percent
 
 
 =item Definition
@@ -368,6 +374,7 @@ k_max has a value which is an int
 k_step has a value which is an int
 k_list has a value which is a reference to a list where each element is an int
 min_contig_length has a value which is an int
+max_mem_percent has a value which is a float
 
 </pre>
 
@@ -386,6 +393,7 @@ k_max has a value which is an int
 k_step has a value which is an int
 k_list has a value which is a reference to a list where each element is an int
 min_contig_length has a value which is an int
+max_mem_percent has a value which is a float
 
 
 =end text

--- a/lib/MEGAHIT/MEGAHITClient.py
+++ b/lib/MEGAHIT/MEGAHITClient.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 try:
     # baseclient and this client are in a package
     from .baseclient import BaseClient as _BaseClient  # @UnusedImport
-except:
+except ImportError:
     # no they aren't
     from baseclient import BaseClient as _BaseClient  # @Reimport
 
@@ -23,7 +23,7 @@ class MEGAHIT(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login'):
+            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'):
         if url is None:
             raise ValueError('A url is required')
         self._service_ver = None
@@ -57,22 +57,24 @@ class MEGAHIT(object):
            even number, default 10 k_list - list of kmer size (all must be
            odd, in the range 15-127, increment <= 28); override `--k-min',
            `--k-max' and `--k-step' min_contig_length - minimum length of
-           contigs to output, default is 2000 @optional
+           contigs to output, default is 2000 max_mem_percnet - maximum
+           memory to make available to MEGAHIT, as a percentage of available
+           system memory (optional, default = 0.9 or 90%) @optional
            megahit_parameter_preset @optional min_count @optional k_min
            @optional k_max @optional k_step @optional k_list @optional
-           min_contig_length) -> structure: parameter "workspace_name" of
-           String, parameter "read_library_ref" of String, parameter
-           "output_contigset_name" of String, parameter
+           min_contig_length @optional max_mem_percent) -> structure:
+           parameter "workspace_name" of String, parameter "read_library_ref"
+           of String, parameter "output_contigset_name" of String, parameter
            "megahit_parameter_preset" of String, parameter "min_count" of
            Long, parameter "k_min" of Long, parameter "k_max" of Long,
            parameter "k_step" of Long, parameter "k_list" of list of Long,
-           parameter "min_contig_length" of Long
+           parameter "min_contig_length" of Long, parameter "max_mem_percent"
+           of Double
         :returns: instance of type "MegaHitOutput" -> structure: parameter
            "report_name" of String, parameter "report_ref" of String
         """
-        return self._client.call_method(
-            'MEGAHIT.run_megahit',
-            [params], self._service_ver, context)
+        return self._client.call_method('MEGAHIT.run_megahit',
+                                        [params], self._service_ver, context)
 
     def status(self, context=None):
         return self._client.call_method('MEGAHIT.status',

--- a/lib/MEGAHIT/MEGAHITServer.py
+++ b/lib/MEGAHIT/MEGAHITServer.py
@@ -1,22 +1,28 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from wsgiref.simple_server import make_server
-import sys
-import json
-import traceback
 import datetime
-from multiprocessing import Process
+import json
+import os
+import random as _random
+import sys
+import traceback
 from getopt import getopt, GetoptError
-from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError,\
+from multiprocessing import Process
+from os import environ
+from wsgiref.simple_server import make_server
+
+import requests as _requests
+from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError, \
     JSONRPCError, InvalidRequestError
 from jsonrpcbase import ServerError as JSONServerError
-from os import environ
-from ConfigParser import ConfigParser
+
 from biokbase import log
-import requests as _requests
-import random as _random
-import os
 from MEGAHIT.authclient import KBaseAuth as _KBaseAuth
+
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 DEPLOY = 'KB_DEPLOYMENT_CONFIG'
 SERVICE = 'KB_SERVICE_NAME'
@@ -109,11 +115,10 @@ class JSONRPCServiceCustom(JSONRPCService):
             # Exception was raised inside the method.
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
-            if isinstance(e.message, basestring):
-                newerr.data = e.message
+            if len(e.args) == 1:
+                newerr.data = repr(e.args[0])
             else:
-                # Some exceptions embed other exceptions as the message
-                newerr.data = repr(e.message)
+                newerr.data = repr(e.args)
             raise newerr
         return result
 
@@ -175,7 +180,7 @@ class JSONRPCServiceCustom(JSONRPCService):
 
     def _handle_request(self, ctx, request):
         """Handles given request and returns its response."""
-        if self.method_data[request['method']].has_key('types'):  # noqa @IgnorePep8
+        if 'types' in self.method_data[request['method']]:
             self._validate_params_types(request['method'], request['params'])
 
         result = self._call_method(ctx, request)
@@ -404,7 +409,7 @@ class Application(object):
                                 ctx['user_id'] = user
                                 ctx['authenticated'] = 1
                                 ctx['token'] = token
-                            except Exception, e:
+                            except Exception as e:
                                 if auth_req == 'required':
                                     err = JSONServerError()
                                     err.data = \
@@ -435,11 +440,11 @@ class Application(object):
                     rpc_result = self.process_error(err, ctx, req,
                                                     traceback.format_exc())
 
-        # print 'Request method was %s\n' % environ['REQUEST_METHOD']
-        # print 'Environment dictionary is:\n%s\n' % pprint.pformat(environ)
-        # print 'Request body was: %s' % request_body
-        # print 'Result from the method call is:\n%s\n' % \
-        #    pprint.pformat(rpc_result)
+        # print('Request method was %s\n' % environ['REQUEST_METHOD'])
+        # print('Environment dictionary is:\n%s\n' % pprint.pformat(environ))
+        # print('Request body was: %s' % request_body)
+        # print('Result from the method call is:\n%s\n' % \
+        #    pprint.pformat(rpc_result))
 
         if rpc_result:
             response_body = rpc_result
@@ -453,7 +458,7 @@ class Application(object):
             ('content-type', 'application/json'),
             ('content-length', str(len(response_body)))]
         start_response(status, response_headers)
-        return [response_body]
+        return [response_body.encode('utf8')]
 
     def process_error(self, error, context, request, trace=None):
         if trace:
@@ -505,7 +510,7 @@ try:
 # a wsgi container that has enabled gevent, such as
 # uwsgi with the --gevent option
     if config is not None and config.get('gevent_monkeypatch_all', False):
-        print "Monkeypatching std libraries for async"
+        print("Monkeypatching std libraries for async")
         from gevent import monkey
         monkey.patch_all()
     uwsgi.applications = {'': application}
@@ -529,7 +534,7 @@ def start_server(host='localhost', port=0, newprocess=False):
         raise RuntimeError('server is already running')
     httpd = make_server(host, port, application)
     port = httpd.server_address[1]
-    print "Listening on port %s" % port
+    print("Listening on port %s" % port)
     if newprocess:
         _proc = Process(target=httpd.serve_forever)
         _proc.daemon = True
@@ -608,7 +613,7 @@ if __name__ == "__main__":
         opts, args = getopt(sys.argv[1:], "", ["port=", "host="])
     except GetoptError as err:
         # print help information and exit:
-        print str(err)  # will print something like "option -a not recognized"
+        print(str(err))  # will print something like "option -a not recognized"
         sys.exit(2)
     port = 9999
     host = 'localhost'
@@ -617,12 +622,12 @@ if __name__ == "__main__":
             port = int(a)
         elif o == '--host':
             host = a
-            print "Host set to %s" % host
+            print("Host set to %s" % host)
         else:
             assert False, "unhandled option"
 
     start_server(host=host, port=port)
-#    print "Listening on port %s" % port
+#    print("Listening on port %s" % port)
 #    httpd = make_server( host, port, application)
 #
 #    httpd.serve_forever()

--- a/lib/MEGAHIT/authclient.py
+++ b/lib/MEGAHIT/authclient.py
@@ -24,7 +24,7 @@ class TokenCache(object):
         self._halfmax = maxsize / 2  # int division to round down
 
     def get_user(self, token):
-        token = hashlib.sha256(token).hexdigest()
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
         with self._lock:
             usertime = self._cache.get(token)
         if not usertime:
@@ -40,12 +40,15 @@ class TokenCache(object):
             raise ValueError('Must supply token')
         if not user:
             raise ValueError('Must supply user')
-        token = hashlib.sha256(token).hexdigest()
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
-                for i, (t, _) in enumerate(sorted(self._cache.items(),
-                                                  key=lambda (_, v): v[1])):
+                sorted_items = sorted(
+                    list(self._cache.items()),
+                    key=(lambda v: v[1][1])
+                )
+                for i, (t, _) in enumerate(sorted_items):
                     if i <= self._halfmax:
                         del self._cache[t]
                     else:
@@ -57,7 +60,7 @@ class KBaseAuth(object):
     A very basic KBase auth client for the Python server.
     '''
 
-    _LOGIN_URL = 'https://kbase.us/services/authorization/Sessions/Login'
+    _LOGIN_URL = 'https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login'
 
     def __init__(self, auth_url=None):
         '''
@@ -80,11 +83,11 @@ class KBaseAuth(object):
         if not ret.ok:
             try:
                 err = ret.json()
-            except:
+            except Exception as e:
                 ret.raise_for_status()
             raise ValueError('Error connecting to auth service: {} {}\n{}'
                              .format(ret.status_code, ret.reason,
-                                     err['error_msg']))
+                                     err['error']['message']))
 
         user = ret.json()['user_id']
         self._cache.add_valid_token(token, user)

--- a/lib/MEGAHIT/baseclient.py
+++ b/lib/MEGAHIT/baseclient.py
@@ -11,6 +11,9 @@ import json as _json
 import requests as _requests
 import random as _random
 import os as _os
+import traceback as _traceback
+from requests.exceptions import ConnectionError
+from urllib3.exceptions import ProtocolError
 
 try:
     from configparser import ConfigParser as _ConfigParser  # py 3
@@ -26,6 +29,7 @@ import time
 _CT = 'content-type'
 _AJ = 'application/json'
 _URL_SCHEME = frozenset(['http', 'https'])
+_CHECK_JOB_RETRYS = 3
 
 
 def _get_token(user_id, password, auth_svc):
@@ -121,7 +125,7 @@ class BaseClient(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login',
+            auth_svc='https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login',
             lookup_url=False,
             async_job_check_time_ms=100,
             async_job_check_time_scale_percent=150,
@@ -236,20 +240,30 @@ class BaseClient(object):
         mod, _ = service_method.split('.')
         job_id = self._submit_job(service_method, args, service_ver, context)
         async_job_check_time = self.async_job_check_time
-        while True:
+        check_job_failures = 0
+        while check_job_failures < _CHECK_JOB_RETRYS:
             time.sleep(async_job_check_time)
             async_job_check_time = (async_job_check_time *
                                     self.async_job_check_time_scale_percent /
                                     100.0)
             if async_job_check_time > self.async_job_check_max_time:
                 async_job_check_time = self.async_job_check_max_time
-            job_state = self._check_job(mod, job_id)
+
+            try:
+                job_state = self._check_job(mod, job_id)
+            except (ConnectionError, ProtocolError):
+                _traceback.print_exc()
+                check_job_failures += 1
+                continue
+
             if job_state['finished']:
                 if not job_state['result']:
                     return
                 if len(job_state['result']) == 1:
                     return job_state['result'][0]
                 return job_state['result']
+        raise RuntimeError("_check_job failed {} times and exceeded limit".format(
+            check_job_failures))
 
     def call_method(self, service_method, args, service_ver=None,
                     context=None):

--- a/lib/MEGAHIT/error.py
+++ b/lib/MEGAHIT/error.py
@@ -1,0 +1,27 @@
+import os
+
+def report_megahit_error(output_dir, retcode):
+    # look for the file "<output_dir>/log"
+    # If present, slurp it in and look for the line(s) with "[ERROR]" at the front and
+    # return them as the error
+    # Also, dump the MEGAHIT log out to the job run log.
+    error_str = "Error running MEGAHIT, return code: " + str(retcode)
+    logfile = os.path.join(output_dir, "log")
+    error_lines = list()
+
+    ERROR_BLOCK = "[ERROR]"
+
+    if os.path.exists(logfile):
+        print("MEGAHIT RUN LOG\n===============\n")
+        with open(logfile, "r") as log:
+            for count, line in enumerate(log):
+                print(line)  # dump to the log.
+                line = line.strip()
+                if line.startswith(ERROR_BLOCK):
+                    error_lines.append(line.split(ERROR_BLOCK)[-1])
+    else:
+        error_str += "\nUnable to find MEGAHIT log."
+
+    if error_lines:
+        error_str += "\nAdditional Information\n" + "\n".join(error_lines)
+    return error_str

--- a/lib/src/us/kbase/megahit/MegaHitParams.java
+++ b/lib/src/us/kbase/megahit/MegaHitParams.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * workspace_name - the name of the workspace for input/output
  * read_library_ref - the name of the PE read library (SE library support in the future)
  * output_contig_set_name - the name of the output contigset
- * megahit_parameter_preset - 
+ * megahit_parameter_preset -
  *         override a group of parameters; possible values:
  *             meta            '--min-count 2 --k-list 21,41,61,81,99'
  *             (generic metagenomes, default)
@@ -38,6 +38,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *         k_list - list of kmer size (all must be odd, in the range 15-127, increment <= 28);
  *  override `--k-min', `--k-max' and `--k-step'
  * min_contig_length - minimum length of contigs to output, default is 2000
+ * max_mem_percnet - maximum memory to make available to MEGAHIT, as a percentage of
+ *                                   available system memory (optional, default = 0.9 or 90%)
  * @optional megahit_parameter_preset
  * @optional min_count
  * @optional k_min
@@ -45,6 +47,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * @optional k_step
  * @optional k_list
  * @optional min_contig_length
+ * @optional max_mem_percent
  * </pre>
  * 
  */
@@ -60,7 +63,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "k_max",
     "k_step",
     "k_list",
-    "min_contig_length"
+    "min_contig_length",
+    "max_mem_percent"
 })
 public class MegaHitParams {
 
@@ -84,6 +88,8 @@ public class MegaHitParams {
     private List<Long> kList;
     @JsonProperty("min_contig_length")
     private java.lang.Long minContigLength;
+    @JsonProperty("max_mem_percent")
+    private Double maxMemPercent;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("workspace_name")
@@ -236,6 +242,21 @@ public class MegaHitParams {
         return this;
     }
 
+    @JsonProperty("max_mem_percent")
+    public Double getMaxMemPercent() {
+        return maxMemPercent;
+    }
+
+    @JsonProperty("max_mem_percent")
+    public void setMaxMemPercent(Double maxMemPercent) {
+        this.maxMemPercent = maxMemPercent;
+    }
+
+    public MegaHitParams withMaxMemPercent(Double maxMemPercent) {
+        this.maxMemPercent = maxMemPercent;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -248,7 +269,7 @@ public class MegaHitParams {
 
     @Override
     public String toString() {
-        return ((((((((((((((((((((((("MegaHitParams"+" [workspaceName=")+ workspaceName)+", readLibraryRef=")+ readLibraryRef)+", outputContigsetName=")+ outputContigsetName)+", megahitParameterPreset=")+ megahitParameterPreset)+", minCount=")+ minCount)+", kMin=")+ kMin)+", kMax=")+ kMax)+", kStep=")+ kStep)+", kList=")+ kList)+", minContigLength=")+ minContigLength)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((("MegaHitParams"+" [workspaceName=")+ workspaceName)+", readLibraryRef=")+ readLibraryRef)+", outputContigsetName=")+ outputContigsetName)+", megahitParameterPreset=")+ megahitParameterPreset)+", minCount=")+ minCount)+", kMin=")+ kMin)+", kMax=")+ kMax)+", kStep=")+ kStep)+", kList=")+ kList)+", minContigLength=")+ minContigLength)+", maxMemPercent=")+ maxMemPercent)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/test/MegaHit_server_test.py
+++ b/test/MegaHit_server_test.py
@@ -182,4 +182,24 @@ class MegaHitTest(unittest.TestCase):
         self.assertEqual(contigset_info[2].split('-')[0], 'KBaseGenomeAnnotations.Assembly')
         self.assertEqual(contigset_info[10]['Size'], '64794')
 
+    def test_run_megahit_oom_error(self):
+        # force MEGAHIT to use waaaay less than enough memory to trigger the error
 
+        pe_lib_info = self.getPairedEndLibInfo()
+        # run megahit
+        params = {
+            'workspace_name': pe_lib_info[7],
+            'read_library_ref': pe_lib_info[7] + '/' + pe_lib_info[1],
+            'megahit_parameter_preset': 'meta-sensitive',
+            'output_contigset_name': 'output.contigset',
+            'max_mem_percent': 0.001
+        }
+
+        with self.assertRaises(RuntimeError) as e:
+            self.getImpl().run_megahit(self.getContext(), params)
+
+        err_str = str(e.exception)
+        print("Successfully triggered OOM error!\n" + err_str)
+        self.assertIn("Error running MEGAHIT, return code", err_str)
+        self.assertIn("Additional Information", err_str)
+        self.assertIn("please set -m parameter to at least", err_str)


### PR DESCRIPTION
This does a few things.
1. Introduce a new optional parameter - `max_mem_percent`, which is the percent of available system memory to use. (default = 90%, set by MEGAHIT when the `-m` flag isn't used, but put here explicitly to hopefully trigger the error log text)

2. On a nonzero return code, look for a log in the output directory (standard MEGAHIT practice is put a log file called `log` in the output dir.) Dump it to the output logs, and skim it for "[ERROR]" token lines - these get appended to the error text and should include memory requirements.