### PR TITLE
New MEGAHIT error reporting

### DIFF
--- a/MEGAHIT.spec
+++ b/MEGAHIT.spec
@@ -11,7 +11,7 @@ module MEGAHIT {
 		read_library_ref - the name of the PE read library (SE library support in the future)
 		output_contig_set_name - the name of the output contigset
 
-		megahit_parameter_preset - 
+		megahit_parameter_preset -
 			override a group of parameters; possible values:
             meta            '--min-count 2 --k-list 21,41,61,81,99'
                             (generic metagenomes, default)
@@ -35,6 +35,9 @@ module MEGAHIT {
 
 		min_contig_length - minimum length of contigs to output, default is 2000
 
+		max_mem_percent - maximum memory to make available to MEGAHIT, as a percentage of
+											available system memory (optional, default = 0.9 or 90%)
+
 		@optional megahit_parameter_preset
 		@optional min_count
 		@optional k_min
@@ -42,6 +45,7 @@ module MEGAHIT {
 		@optional k_step
 		@optional k_list
 		@optional min_contig_length
+		@optional max_mem_percent
 	*/
 	typedef structure {
 		string workspace_name;
@@ -56,6 +60,7 @@ module MEGAHIT {
 		int k_step;
 		list <int> k_list;
 		int min_contig_length;
+		float max_mem_percent;
 	} MegaHitParams;
 
 

--- a/lib/MEGAHIT/MEGAHITClient.py
+++ b/lib/MEGAHIT/MEGAHITClient.py
@@ -23,7 +23,7 @@ class MEGAHIT(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://appdev.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'):
+            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'):
         if url is None:
             raise ValueError('A url is required')
         self._service_ver = None
@@ -57,16 +57,19 @@ class MEGAHIT(object):
            even number, default 10 k_list - list of kmer size (all must be
            odd, in the range 15-127, increment <= 28); override `--k-min',
            `--k-max' and `--k-step' min_contig_length - minimum length of
-           contigs to output, default is 2000 @optional
+           contigs to output, default is 2000 max_mem_percent - maximum
+           memory to make available to MEGAHIT, as a percentage of available
+           system memory (optional, default = 0.9 or 90%) @optional
            megahit_parameter_preset @optional min_count @optional k_min
            @optional k_max @optional k_step @optional k_list @optional
-           min_contig_length) -> structure: parameter "workspace_name" of
-           String, parameter "read_library_ref" of String, parameter
-           "output_contigset_name" of String, parameter
+           min_contig_length @optional max_mem_percent) -> structure:
+           parameter "workspace_name" of String, parameter "read_library_ref"
+           of String, parameter "output_contigset_name" of String, parameter
            "megahit_parameter_preset" of String, parameter "min_count" of
            Long, parameter "k_min" of Long, parameter "k_max" of Long,
            parameter "k_step" of Long, parameter "k_list" of list of Long,
-           parameter "min_contig_length" of Long
+           parameter "min_contig_length" of Long, parameter "max_mem_percent"
+           of Double
         :returns: instance of type "MegaHitOutput" -> structure: parameter
            "report_name" of String, parameter "report_ref" of String
         """

--- a/lib/MEGAHIT/MEGAHITImpl.py
+++ b/lib/MEGAHIT/MEGAHITImpl.py
@@ -16,6 +16,9 @@ from installed_clients.AssemblyUtilClient import AssemblyUtil
 from installed_clients.KBaseReportClient import KBaseReport
 from installed_clients.baseclient import ServerError
 from installed_clients.kb_quastClient import kb_quast
+
+from .error import report_megahit_error
+
 #END_HEADER
 
 
@@ -35,8 +38,8 @@ class MEGAHIT:
     # the latter method is running.
     ######################################### noqa
     VERSION = "2.4.0"
-    GIT_URL = "https://github.com/kbaseapps/kb_megahit"
-    GIT_COMMIT_HASH = "1f033cc88194b94ac69a39df956cf96a343cc1c7"
+    GIT_URL = "https://github.com/briehl/kb_megahit"
+    GIT_COMMIT_HASH = "c0264e2b3f9080055ac32f7d7fa58f9a2dbae574"
 
     #BEGIN_CLASS_HEADER
     MEGAHIT = '/usr/bin/megahit'
@@ -91,16 +94,19 @@ class MEGAHIT:
            even number, default 10 k_list - list of kmer size (all must be
            odd, in the range 15-127, increment <= 28); override `--k-min',
            `--k-max' and `--k-step' min_contig_length - minimum length of
-           contigs to output, default is 2000 @optional
+           contigs to output, default is 2000 max_mem_percent - maximum
+           memory to make available to MEGAHIT, as a percentage of available
+           system memory (optional, default = 0.9 or 90%) @optional
            megahit_parameter_preset @optional min_count @optional k_min
            @optional k_max @optional k_step @optional k_list @optional
-           min_contig_length) -> structure: parameter "workspace_name" of
-           String, parameter "read_library_ref" of String, parameter
-           "output_contigset_name" of String, parameter
+           min_contig_length @optional max_mem_percent) -> structure:
+           parameter "workspace_name" of String, parameter "read_library_ref"
+           of String, parameter "output_contigset_name" of String, parameter
            "megahit_parameter_preset" of String, parameter "min_count" of
            Long, parameter "k_min" of Long, parameter "k_max" of Long,
            parameter "k_step" of Long, parameter "k_list" of list of Long,
-           parameter "min_contig_length" of Long
+           parameter "min_contig_length" of Long, parameter "max_mem_percent"
+           of Double
         :returns: instance of type "MegaHitOutput" -> structure: parameter
            "report_name" of String, parameter "report_ref" of String
         """
@@ -186,7 +192,17 @@ class MEGAHIT:
 
         # Set the number of CPUs to the number of cores minus 1
         megahit_cmd.append('--num-cpu-threads')
-        megahit_cmd.append(str(multiprocessing.cpu_count() - 1))
+        megahit_cmd.append(str(max([(multiprocessing.cpu_count() - 1), 1])))
+
+        # set mem usage
+        # Note: this just sets the default value - 90% of available system memory allocated
+        # to the container. Exposing it here as a place to later expose as a parameter.
+        max_mem_percent = params.get('max_mem_percent', 0.9)
+        megahit_cmd.append('-m')
+        megahit_cmd.append(str(max_mem_percent))
+
+        megahit_cmd.append('--mem-flag')
+        megahit_cmd.append('0')
 
         # set the output location
         timestamp = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds() * 1000)
@@ -202,8 +218,8 @@ class MEGAHIT:
 
         print('Return code: ' + str(retcode))
         if p.returncode != 0:
-            raise ValueError('Error running MEGAHIT, return code: ' +
-                             str(retcode) + '\n')
+            error_str = report_megahit_error(output_dir, retcode)
+            raise RuntimeError(error_str)
 
         output_contigs = os.path.join(output_dir, 'final.contigs.fa')
 

--- a/lib/MEGAHIT/MEGAHITImpl.py
+++ b/lib/MEGAHIT/MEGAHITImpl.py
@@ -201,9 +201,6 @@ class MEGAHIT:
         megahit_cmd.append('-m')
         megahit_cmd.append(str(max_mem_percent))
 
-        megahit_cmd.append('--mem-flag')
-        megahit_cmd.append('0')
-
         # set the output location
         timestamp = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds() * 1000)
         output_dir = os.path.join(self.scratch, 'output.' + str(timestamp))

--- a/lib/MEGAHIT/error.py
+++ b/lib/MEGAHIT/error.py
@@ -1,0 +1,27 @@
+import os
+
+def report_megahit_error(output_dir, retcode):
+    # look for the file "<output_dir>/log"
+    # If present, slurp it in and look for the line(s) with "[ERROR]" at the front and
+    # return them as the error
+    # Also, dump the MEGAHIT log out to the job run log.
+    error_str = "Error running MEGAHIT, return code: " + str(retcode)
+    logfile = os.path.join(output_dir, "log")
+    error_lines = list()
+
+    ERROR_BLOCK = "[ERROR]"
+
+    if os.path.exists(logfile):
+        print("MEGAHIT RUN LOG\n===============\n")
+        with open(logfile, "r") as log:
+            for count, line in enumerate(log):
+                print(line)  # dump to the log.
+                line = line.strip()
+                if line.startswith(ERROR_BLOCK):
+                    error_lines.append(line.split(ERROR_BLOCK)[-1])
+    else:
+        error_str += "\nUnable to find MEGAHIT log."
+
+    if error_lines:
+        error_str += "\nAdditional Information\n" + "\n".join(error_lines)
+    return error_str

--- a/lib/src/us/kbase/megahit/MegaHitParams.java
+++ b/lib/src/us/kbase/megahit/MegaHitParams.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * workspace_name - the name of the workspace for input/output
  * read_library_ref - the name of the PE read library (SE library support in the future)
  * output_contig_set_name - the name of the output contigset
- * megahit_parameter_preset - 
+ * megahit_parameter_preset -
  *         override a group of parameters; possible values:
  *             meta            '--min-count 2 --k-list 21,41,61,81,99'
  *             (generic metagenomes, default)
@@ -38,6 +38,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *         k_list - list of kmer size (all must be odd, in the range 15-127, increment <= 28);
  *  override `--k-min', `--k-max' and `--k-step'
  * min_contig_length - minimum length of contigs to output, default is 2000
+ * max_mem_percent - maximum memory to make available to MEGAHIT, as a percentage of
+ *                                                                         available system memory (optional, default = 0.9 or 90%)
  * @optional megahit_parameter_preset
  * @optional min_count
  * @optional k_min
@@ -45,6 +47,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * @optional k_step
  * @optional k_list
  * @optional min_contig_length
+ * @optional max_mem_percent
  * </pre>
  * 
  */
@@ -60,7 +63,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "k_max",
     "k_step",
     "k_list",
-    "min_contig_length"
+    "min_contig_length",
+    "max_mem_percent"
 })
 public class MegaHitParams {
 
@@ -84,6 +88,8 @@ public class MegaHitParams {
     private List<Long> kList;
     @JsonProperty("min_contig_length")
     private java.lang.Long minContigLength;
+    @JsonProperty("max_mem_percent")
+    private Double maxMemPercent;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("workspace_name")
@@ -236,6 +242,21 @@ public class MegaHitParams {
         return this;
     }
 
+    @JsonProperty("max_mem_percent")
+    public Double getMaxMemPercent() {
+        return maxMemPercent;
+    }
+
+    @JsonProperty("max_mem_percent")
+    public void setMaxMemPercent(Double maxMemPercent) {
+        this.maxMemPercent = maxMemPercent;
+    }
+
+    public MegaHitParams withMaxMemPercent(Double maxMemPercent) {
+        this.maxMemPercent = maxMemPercent;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -248,7 +269,7 @@ public class MegaHitParams {
 
     @Override
     public String toString() {
-        return ((((((((((((((((((((((("MegaHitParams"+" [workspaceName=")+ workspaceName)+", readLibraryRef=")+ readLibraryRef)+", outputContigsetName=")+ outputContigsetName)+", megahitParameterPreset=")+ megahitParameterPreset)+", minCount=")+ minCount)+", kMin=")+ kMin)+", kMax=")+ kMax)+", kStep=")+ kStep)+", kList=")+ kList)+", minContigLength=")+ minContigLength)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((("MegaHitParams"+" [workspaceName=")+ workspaceName)+", readLibraryRef=")+ readLibraryRef)+", outputContigsetName=")+ outputContigsetName)+", megahitParameterPreset=")+ megahitParameterPreset)+", minCount=")+ minCount)+", kMin=")+ kMin)+", kMax=")+ kMax)+", kStep=")+ kStep)+", kList=")+ kList)+", minContigLength=")+ minContigLength)+", maxMemPercent=")+ maxMemPercent)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/test/MegaHit_server_test.py
+++ b/test/MegaHit_server_test.py
@@ -165,3 +165,26 @@ class MegaHitTest(unittest.TestCase):
         self.assertEqual(contigset_info[1], 'trimmed.output.contigset')
         self.assertEqual(contigset_info[2].split('-')[0], 'KBaseGenomeAnnotations.Assembly')
         self.assertEqual(contigset_info[10]['Size'], '64794')
+
+    @unittest.skip("Skipping OOM test")
+    def test_run_megahit_oom_error(self):
+        # force MEGAHIT to use waaaay less than enough memory to trigger the error
+
+        pe_lib_info = self.getPairedEndLibInfo()
+        # run megahit
+        params = {
+            'workspace_name': pe_lib_info[7],
+            'read_library_ref': pe_lib_info[7] + '/' + pe_lib_info[1],
+            'megahit_parameter_preset': 'meta-sensitive',
+            'output_contigset_name': 'output.contigset',
+            'max_mem_percent': 2
+        }
+
+        with self.assertRaises(RuntimeError) as e:
+            self.getImpl().run_megahit(self.getContext(), params)
+
+        err_str = str(e.exception)
+        print("Successfully triggered OOM error!\n" + err_str)
+        self.assertIn("Error running MEGAHIT, return code", err_str)
+        self.assertIn("Additional Information", err_str)
+        self.assertIn("please set -m parameter to at least", err_str)


### PR DESCRIPTION
This does a few things.

Introduce a new optional parameter - max_mem_percent, which is the percent of available system memory to use. (default = 90%, set by MEGAHIT when the -m flag isn't used, but put here explicitly to hopefully trigger the error log text)

On a nonzero return code, look for a log in the output directory (standard MEGAHIT practice is put a log file called log in the output dir.) Dump it to the output logs, and skim it for "[ERROR]" token lines - these get appended to the error text and should include memory requirements.

