### PR TITLE
Add a note about module authors

### DIFF
--- a/ui/narrative/methods/run_megahit/display.yaml
+++ b/ui/narrative/methods/run_megahit/display.yaml
@@ -75,6 +75,15 @@ description : |
       </ul>
       </p>
 
+  <p>
+    KBase module authors:
+    <ul>
+      <li> Michael Sneddon </li>
+      <li> Roman Sutormin </li>
+      <li> Dylan Chivian </li>
+    </ul>
+  </p>
+
 publications :
     -
         pmid: 25609793


### PR DESCRIPTION
@bio-boris Adding authors in display.yaml like we discussed. Looking through the commit history, msneddon seems to be the primary author. Let me know if you can think of anything else to put in the display.yaml besides their names.