### PR TITLE
PTV-1772 Pass min contig length to QUAST

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### Version 2.4.3
+__Fixed__
+- The app now passes the min_contig_length to QUAST to prevent errors when the user specifies a
+  MCL < the QUAST default.
+
 ### Version 2.4.2
 __Fixed__
 - Corrected the min and max ranges for k_min, k_max, k_step, and k_list

--- a/kbase.yml
+++ b/kbase.yml
@@ -11,7 +11,7 @@ service-language:
     python
 
 module-version:
-    2.4.2
+    2.4.3
 
 owners:
-    [dylan, jayrbolton, bsadkhin]
+    [dylan, bsadkhin, gaprice]

--- a/test/MegaHit_server_test.py
+++ b/test/MegaHit_server_test.py
@@ -11,6 +11,7 @@ from installed_clients.WorkspaceClient import Workspace as workspaceService
 from MEGAHIT.MEGAHITImpl import MEGAHIT
 from installed_clients.ReadsUtilsClient import ReadsUtils
 
+# TODO switch to pytest and ditch the class and self.assert*
 
 class MegaHitTest(unittest.TestCase):
 
@@ -165,6 +166,21 @@ class MegaHitTest(unittest.TestCase):
         self.assertEqual(contigset_info[1], 'trimmed.output.contigset')
         self.assertEqual(contigset_info[2].split('-')[0], 'KBaseGenomeAnnotations.Assembly')
         self.assertEqual(contigset_info[10]['Size'], '64794')
+
+    def test_run_megahit_with_bad_MCL(self):
+        params = {
+            'workspace_name': "fake",
+            'read_library_ref': "alsofake",
+            'output_contigset_name': "I, too, am fake",
+            'min_contig_length': None
+        }
+
+        for mcl in ["foo", 49, 10, 1, 0, -1, -100, -100000]:
+            with self.assertRaises(ValueError) as e:
+                params['min_contig_length'] = mcl
+                self.getImpl().run_megahit(self.getContext(), params)
+            self.assertEqual(
+                str(e.exception), "min_contig_length parameter must be an integer >= 50")
 
     @unittest.skip("Skipping OOM test")
     def test_run_megahit_oom_error(self):


### PR DESCRIPTION
Quast uses 500 by default, which may cause issues if the user specifies an MCL less than that.

There are very few tests in the test suite and none at all for the QUAST output, so I don't propose to spend a massive amount of time adding them. I checked the KBaseReports for both tests manually and confirmed that QUAST got the correct MCL.